### PR TITLE
docs: Fixed asynchronous error in NewsService list method by adding '…

### DIFF
--- a/site/docs/intro/quickstart.md
+++ b/site/docs/intro/quickstart.md
@@ -275,9 +275,9 @@ class NewsService extends Service {
 
     // parallel GET detail
     const newsList = await Promise.all(
-      Object.keys(idList).map((key) => {
+      Object.keys(idList).map(async (key) => {
         const url = `${serverUrl}/item/${idList[key]}.json`;
-        return this.ctx.curl(url, { dataType: 'json' });
+        return await this.ctx.curl(url, { dataType: 'json' });
       }),
     );
     return newsList.map((res) => res.data);


### PR DESCRIPTION
…async' and 'await' (https://github.com/eggjs/egg/pull/5301)

This commit fixed an asynchronous error in the NewsService list method. I added the 'async' keyword and used 'await' to fetch data in each iteration. This ensures that the NewsService class can fetch news data from the Hacker News API efficiently and without errors.